### PR TITLE
core(node) Move to setting exitCode vs calling exit(code)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,12 +28,20 @@ startPoolHall(
 
     process.on('SIGTERM', () => {
       console.log('Got SIGTERM. Going down.');
-      poolHall.stop().then(() => process.exit(0), () => process.exit(1));
+      poolHall.stop().then(() => {
+        process.exitCode = 0;
+      }, () => {
+        process.exitCode = 1;
+      });
     });
 
     process.on('SIGINT', () => {
       console.log('Got SIGINT. Going down.');
-      poolHall.stop().then(() => process.exit(0), () => process.exit(1));
+      poolHall.stop().then(() => {
+        process.exitCode = 0;
+      }, () => {
+        process.exitCode = 1;
+      });
     });
 
     poolHall.on('workerUp', (id) => {
@@ -94,6 +102,8 @@ startPoolHall(
 
     const server = app.listen(process.env.PORT, "localhost", ready);
 
-    poolHall.worker.onShutdown = () => server.close(() => process.exit(0));
+    poolHall.worker.onShutdown = () => server.close(() => {
+      process.exitCode = 0;
+    });
   }
 );


### PR DESCRIPTION
We had an issue with `process.exit(code)` at webpack in the past where Node.js did not exit itself after the `process.exit(1)` was called.

https://nodejs.org/dist/latest-v9.x/docs/api/process.html#process_process_exit_code

> Rather than calling process.exit() directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop.

For details you can see old PR with issue.
webpack/webpack#6193

